### PR TITLE
removed connect and added useSelector and useDispatch

### DIFF
--- a/src/components/containers/AllInstructorsContainer.js
+++ b/src/components/containers/AllInstructorsContainer.js
@@ -1,39 +1,18 @@
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
 import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { fetchAllInstructorsThunk } from "../../store/thunks";
 import { AllInstructorsView } from "../views";
 
-function AllInstructorsContainer({ allInstructors, fetchAllInstructors }) {
-useEffect(() => {
-   fetchAllInstructors();
+function AllInstructorsContainer() {
+  const allInstructors = useSelector((state) => state.allInstructors);
+  const dispatch = useDispatch();
 
-   // IMPORTANT: DO NOT REMOVE THE COMMENT BELOW
-   // eslint-disable-next-line react-hooks/exhaustive-deps
-}, []) 
+  //replaces componentDidMount
+  useEffect(() => {
+    dispatch(fetchAllInstructorsThunk());
+  }, [dispatch]);
 
   return <AllInstructorsView allInstructors={allInstructors} />;
 }
 
-// Map state to props;
-const mapState = (state) => {
-  return {
-    allInstructors: state.allInstructors,
-  };
-};
-
-// Map dispatch to props;
-const mapDispatch = (dispatch) => {
-  return {
-    fetchAllInstructors: () => dispatch(fetchAllInstructorsThunk()),
-  };
-};
-
-// Type check props;
-AllInstructorsContainer.propTypes = {
-  allInstructors: PropTypes.array.isRequired,
-  fetchAllInstructors: PropTypes.func.isRequired,
-};
-
-// Export our store-connected container by default;
-export default connect(mapState, mapDispatch)(AllInstructorsContainer);
+export default AllInstructorsContainer;


### PR DESCRIPTION
This change removes the need for connect, mapDispatchToProps, and mapStateToProps. [More reference here.](https://react-redux.js.org/api/hooks)